### PR TITLE
Introduce a `Clearable` trait to support unsized types

### DIFF
--- a/src/clear_on_drop.rs
+++ b/src/clear_on_drop.rs
@@ -3,7 +3,6 @@ use std::hash::{Hash,Hasher};
 use std::ops::{Deref, DerefMut};
 use std::borrow::{Borrow, BorrowMut};
 
-use hide::hide_mem;
 use clearable::Clearable;
 
 /// Zeroizes a storage location when dropped.
@@ -74,7 +73,6 @@ impl<T, P> Drop for ClearOnDrop<T, P>
     fn drop(&mut self) {
         let place = self.deref_mut();
         unsafe { place.clear(); }
-        hide_mem::<T>(place);
     }
 }
 

--- a/src/clear_on_drop.rs
+++ b/src/clear_on_drop.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::ops::{Deref, DerefMut};
+use std::borrow::{Borrow, BorrowMut};
 
 use hide::hide_mem;
 use clearable::Clearable;
@@ -125,6 +126,26 @@ impl<T, P> AsMut<T> for ClearOnDrop<T, P>
     #[inline]
     fn as_mut(&mut self) -> &mut T {
         AsMut::as_mut(&mut self._place)
+    }
+}
+
+impl<T, P> Borrow<T> for ClearOnDrop<T, P>
+    where T: Clearable + ?Sized,
+          P: Deref<Target = T> + DerefMut + Borrow<T> 
+{
+    #[inline]
+    fn borrow(&self) -> &T {
+        Borrow::borrow(&self._place)
+    }
+}
+
+impl<T, P> BorrowMut<T> for ClearOnDrop<T, P>
+    where T: Clearable + ?Sized,
+          P: Deref<Target = T> + DerefMut + BorrowMut<T>
+{
+    #[inline]
+    fn borrow_mut(&mut self) -> &mut T {
+        BorrowMut::borrow_mut(&mut self._place)
     }
 }
 

--- a/src/clearable.rs
+++ b/src/clearable.rs
@@ -1,9 +1,9 @@
 /// Types that can safely be dropped after first being overwritten by zeros.
 ///
-/// There is a default implementation for all `Copy` types and all unsized
-/// arrays of `Clerable` types.  You need to implement `Clerable` yourself
-/// for unsized structs, or if your type could be `Copy` but you do not
-/// want it to be.
+/// There is a default implementation for all `Copy+Default` types and all 
+/// unsized arrays of `Clerable` types.  You need to implement `Clerable` 
+/// yourself for unsized structs, or if your type could be `Copy+Default` 
+/// but you do not want it to be.
 ///
 /// ```
 /// # use clear_on_drop::Clearable;
@@ -15,19 +15,22 @@
 /// }
 /// ```
 ///
-/// Warning: `Shared<T>` is `Copy` and hence `Clearable`.  At present, no
-/// other pointer types are `Copy`, but future abstractions built using
-/// `Shared<T>` might be `Copy` and hence `Clearable`, including perhaps
-/// garbage collected abstractions.  Using these could result in memory
-/// leaks or calling `drop` with a null pointer.
+/// We need `Copy` to prevent pointer types like `&mut T` `Box<T>`,
+/// `Arc<T>`, etc. from being `Clearable`.  We need `Default` bound only
+/// because `Shared<T>` is `Copy`.  At present, `Shared<T>` is the only
+/// "bad" `Copy` type, but future abstractions built using `Shared<T>`
+/// might be `Copy`, including perhaps garbage collected abstractions.  
+/// Using these could result in memory leaks or calling `drop` with a
+/// null pointer.
+
 pub unsafe trait Clearable {
-    /// Clear data by dropping it and overwriting it with zeros, 
-    /// possibly leaving in an unusable state.  The object must
-    /// be safe to drop again after being overwritten with zeros.
+    /// Clear data by dropping it and overwriting it with fixed data, 
+    /// possibly leaving in an unusable state.  The object must be
+    /// safe to drop again after being overwritten with zeros however.
     unsafe fn clear(&mut self);
 }
 
-unsafe impl<T> Clearable for T where T: Copy {
+unsafe impl<T> Clearable for T where T: Copy+Default {
     unsafe fn clear(&mut self) {
         *self = ::std::mem::zeroed::<Self>();
         // Assigning like this is equivelent to 
@@ -35,6 +38,9 @@ unsafe impl<T> Clearable for T where T: Copy {
         //   ::std::ptr::write_unaligned::<T>(self, ::std::mem::zeroed::<Self>())
         // because the safety notes on ptr::read say it drops the value
         // previously at *self.
+        ::std::ptr::write::<Self>(self, Default::default());
+        // Should this be ::std::ptr::write_unaligned?
+        // see https://github.com/rust-lang/rust/issues/37955
     }
 }
 

--- a/src/clearable.rs
+++ b/src/clearable.rs
@@ -1,0 +1,48 @@
+/// Types that can safely be dropped after first being overwritten by zeros.
+///
+/// There is a default implementation for all `Copy` types and all unsized
+/// arrays of `Clerable` types.  You need to implement `Clerable` yourself
+/// for unsized structs, or if your type could be `Copy` but you do not
+/// want it to be.
+///
+/// ```
+/// # use clear_on_drop::Clearable;
+/// struct MyNonCopyType([u8; 128]);
+/// unsafe impl Clearable for MyNonCopyType {
+///     unsafe fn clear(&mut self) {
+///         *self = ::std::mem::zeroed::<MyNonCopyType>();
+///     }
+/// }
+/// ```
+///
+/// Warning: `Shared<T>` is `Copy` and hence `Clearable`.  At present, no
+/// other pointer types are `Copy`, but future abstractions built using
+/// `Shared<T>` might be `Copy` and hence `Clearable`, including perhaps
+/// garbage collected abstractions.  Using these could result in memory
+/// leaks or calling `drop` with a null pointer.
+pub unsafe trait Clearable {
+    /// Clear data by dropping it and overwriting it with zeros, 
+    /// possibly leaving in an unusable state.  The object must
+    /// be safe to drop again after being overwritten with zeros.
+    unsafe fn clear(&mut self);
+}
+
+unsafe impl<T> Clearable for T where T: Copy {
+    unsafe fn clear(&mut self) {
+        *self = ::std::mem::zeroed::<Self>();
+        // Assigning like this is equivelent to 
+        //   ::std::ptr::drop_in_place::<Self>(self);
+        //   ::std::ptr::write_unaligned::<T>(self, ::std::mem::zeroed::<Self>())
+        // because the safety notes on ptr::read say it drops the value
+        // previously at *self.
+    }
+}
+
+unsafe impl<T> Clearable for [T] where T: Clearable {
+    unsafe fn clear(&mut self) {
+        for s in self.iter_mut() {
+            *s = ::std::mem::zeroed::<T>();
+        }
+    }
+}
+

--- a/src/clearable.rs
+++ b/src/clearable.rs
@@ -3,11 +3,11 @@ use hide::hide_mem;
 
 /// Types that can safely be dropped after first being overwritten by zeros.
 ///
-/// There is a default implementation for all `Copy` types and all unsized
-/// arrays `[T]` where `T: Clerable`.  You need to implement `Clerable`
-/// yourself for unsized structs, or if your type could be `Copy` but you
-/// do not want it to be, but do so by calling `Clerable::clear` on their
-/// component `Copy` types and arrays.
+/// There is a default implementation for all `Copy+Default` types and all 
+/// unsized arrays `[T]` where `T: Clerable`.  You may implement `Clerable`
+/// yourself for unsized structs, or if your type could be `Copy+Default`
+/// but you do not want it to be, but do so by calling `Clerable::clear` on
+/// their component `Copy+Default` types and `Clearable` arrays.
 ///
 /// ```
 /// # type SomeCopyType = [u8; 128];
@@ -20,19 +20,22 @@ use hide::hide_mem;
 /// }
 /// ```
 ///
-/// Warning: `Shared<T>` is `Copy` and hence `Clearable`.  At present, no
-/// other pointer types are `Copy`, but future abstractions built using
-/// `Shared<T>` might be `Copy` and hence `Clearable`, including perhaps
-/// garbage collected abstractions.  Using these could result in memory
-/// leaks or calling `drop` with a null pointer.
+/// We need `Copy` to prevent pointer types like `&mut T` `Box<T>`,
+/// `Arc<T>`, etc. from being `Clearable`.  We need `Default` bound only
+/// because `Shared<T>` is `Copy`.  At present, `Shared<T>` is the only
+/// "bad" `Copy` type, but future abstractions built using `Shared<T>`
+/// might be `Copy`, including perhaps garbage collected abstractions.  
+/// Using these could result in memory leaks or calling `drop` with a
+/// null pointer.
+
 pub unsafe trait Clearable {
-    /// Clear data by dropping it and overwriting it with zeros, 
-    /// possibly leaving in an unusable state.  The object must
-    /// be safe to drop again after being overwritten with zeros.
+    /// Clear data by dropping it and overwriting it with fixed data, 
+    /// possibly leaving in an unusable state.  The object must be
+    /// safe to drop again after being overwritten with zeros however.
     unsafe fn clear(&mut self);
 }
 
-unsafe impl<T> Clearable for T where T: Copy {
+unsafe impl<T> Clearable for T where T: Copy+Default {
     #[inline(always)]
     unsafe fn clear(&mut self) {
         *self = ::std::mem::zeroed::<Self>();
@@ -41,6 +44,9 @@ unsafe impl<T> Clearable for T where T: Copy {
         //   ::std::ptr::write_unaligned::<T>(self, ::std::mem::zeroed::<Self>())
         // because the safety notes on ptr::read say it drops the value
         // previously at *self.
+        ::std::ptr::write::<Self>(self, Default::default());
+        // Should this be ::std::ptr::write_unaligned?
+        // see https://github.com/rust-lang/rust/issues/37955
         hide_mem::<T>(self);
     }
 }

--- a/src/clearable.rs
+++ b/src/clearable.rs
@@ -1,16 +1,21 @@
+
+use hide::hide_mem;
+
 /// Types that can safely be dropped after first being overwritten by zeros.
 ///
 /// There is a default implementation for all `Copy` types and all unsized
-/// arrays of `Clerable` types.  You need to implement `Clerable` yourself
-/// for unsized structs, or if your type could be `Copy` but you do not
-/// want it to be.
+/// arrays `[T]` where `T: Clerable`.  You need to implement `Clerable`
+/// yourself for unsized structs, or if your type could be `Copy` but you
+/// do not want it to be, but do so by calling `Clerable::clear` on their
+/// component `Copy` types and arrays.
 ///
 /// ```
+/// # type SomeCopyType = [u8; 128];
 /// # use clear_on_drop::Clearable;
-/// struct MyNonCopyType([u8; 128]);
+/// struct MyNonCopyType(SomeCopyType);
 /// unsafe impl Clearable for MyNonCopyType {
 ///     unsafe fn clear(&mut self) {
-///         *self = ::std::mem::zeroed::<MyNonCopyType>();
+///         self.0.clear();
 ///     }
 /// }
 /// ```
@@ -28,6 +33,7 @@ pub unsafe trait Clearable {
 }
 
 unsafe impl<T> Clearable for T where T: Copy {
+    #[inline(always)]
     unsafe fn clear(&mut self) {
         *self = ::std::mem::zeroed::<Self>();
         // Assigning like this is equivelent to 
@@ -35,13 +41,15 @@ unsafe impl<T> Clearable for T where T: Copy {
         //   ::std::ptr::write_unaligned::<T>(self, ::std::mem::zeroed::<Self>())
         // because the safety notes on ptr::read say it drops the value
         // previously at *self.
+        hide_mem::<T>(self);
     }
 }
 
 unsafe impl<T> Clearable for [T] where T: Clearable {
+    #[inline(always)]
     unsafe fn clear(&mut self) {
         for s in self.iter_mut() {
-            *s = ::std::mem::zeroed::<T>();
+            Clearable::clear(s);
         }
     }
 }

--- a/src/clearable.rs
+++ b/src/clearable.rs
@@ -1,9 +1,9 @@
 /// Types that can safely be dropped after first being overwritten by zeros.
 ///
-/// There is a default implementation for all `Copy+Default` types and all 
-/// unsized arrays of `Clerable` types.  You need to implement `Clerable` 
-/// yourself for unsized structs, or if your type could be `Copy+Default` 
-/// but you do not want it to be.
+/// There is a default implementation for all `Copy` types and all unsized
+/// arrays of `Clerable` types.  You need to implement `Clerable` yourself
+/// for unsized structs, or if your type could be `Copy` but you do not
+/// want it to be.
 ///
 /// ```
 /// # use clear_on_drop::Clearable;
@@ -15,22 +15,19 @@
 /// }
 /// ```
 ///
-/// We need `Copy` to prevent pointer types like `&mut T` `Box<T>`,
-/// `Arc<T>`, etc. from being `Clearable`.  We need `Default` bound only
-/// because `Shared<T>` is `Copy`.  At present, `Shared<T>` is the only
-/// "bad" `Copy` type, but future abstractions built using `Shared<T>`
-/// might be `Copy`, including perhaps garbage collected abstractions.  
-/// Using these could result in memory leaks or calling `drop` with a
-/// null pointer.
-
+/// Warning: `Shared<T>` is `Copy` and hence `Clearable`.  At present, no
+/// other pointer types are `Copy`, but future abstractions built using
+/// `Shared<T>` might be `Copy` and hence `Clearable`, including perhaps
+/// garbage collected abstractions.  Using these could result in memory
+/// leaks or calling `drop` with a null pointer.
 pub unsafe trait Clearable {
-    /// Clear data by dropping it and overwriting it with fixed data, 
-    /// possibly leaving in an unusable state.  The object must be
-    /// safe to drop again after being overwritten with zeros however.
+    /// Clear data by dropping it and overwriting it with zeros, 
+    /// possibly leaving in an unusable state.  The object must
+    /// be safe to drop again after being overwritten with zeros.
     unsafe fn clear(&mut self);
 }
 
-unsafe impl<T> Clearable for T where T: Copy+Default {
+unsafe impl<T> Clearable for T where T: Copy {
     unsafe fn clear(&mut self) {
         *self = ::std::mem::zeroed::<Self>();
         // Assigning like this is equivelent to 
@@ -38,9 +35,6 @@ unsafe impl<T> Clearable for T where T: Copy+Default {
         //   ::std::ptr::write_unaligned::<T>(self, ::std::mem::zeroed::<Self>())
         // because the safety notes on ptr::read say it drops the value
         // previously at *self.
-        ::std::ptr::write::<Self>(self, Default::default());
-        // Should this be ::std::ptr::write_unaligned?
-        // see https://github.com/rust-lang/rust/issues/37955
     }
 }
 

--- a/src/hide.rs
+++ b/src/hide.rs
@@ -10,7 +10,7 @@
 /// Make the optimizer believe the memory pointed to by `ptr` is read
 /// and modified arbitrarily.
 #[inline]
-pub fn hide_mem<T>(ptr: &mut T) {
+pub fn hide_mem<T>(ptr: &mut T) where T: ?Sized {
     hide_mem_impl(ptr);
 }
 
@@ -35,7 +35,7 @@ use self::fallback::*;
 #[cfg(feature = "nightly")]
 mod nightly {
     #[inline]
-    pub fn hide_mem_impl<T>(ptr: *mut T) {
+    pub fn hide_mem_impl<T>(ptr: *mut T) where T: ?Sized {
         unsafe {
             asm!("" : "=*m" (ptr) : "*0" (ptr));
         }
@@ -52,7 +52,7 @@ mod cc {
     }
 
     #[inline]
-    pub fn hide_mem_impl<T>(ptr: *mut T) {
+    pub fn hide_mem_impl<T>(ptr: *mut T) where T: ?Sized {
         unsafe {
             clear_on_drop_hide(ptr as *mut c_void);
         }
@@ -66,7 +66,7 @@ mod fallback {
     use std::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
 
     #[inline]
-    pub fn hide_mem_impl<T>(ptr: *mut T) {
+    pub fn hide_mem_impl<T>(ptr: *mut T) where T: ?Sized {
         static DUMMY: AtomicUsize = ATOMIC_USIZE_INIT;
         DUMMY.store(ptr as usize, Ordering::Release);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,10 +53,12 @@
 //! the `no_cc` feature, works on stable Rust, and does not need a C
 //! compiler.
 
+mod clearable;
 mod clear_on_drop;
 mod clear_stack_on_return;
 mod fnoption;
 mod hide;
 
+pub use clearable::*;
 pub use clear_on_drop::*;
 pub use clear_stack_on_return::*;


### PR DESCRIPTION
Introduce a `Clearable` trait to support unsized types.  Addresses the most concerns in https://github.com/cesarb/clear_on_drop/issues/3 as well, including the warning by @bluss that assignment might not zero everything https://github.com/cesarb/clear_on_drop/issues/3#issuecomment-272745368

I decided to implement `Clearable` for all `Sized+Copy` types because `Shared<T>` is the only dangerous `Copy` type I could find.  there are many pointer types that satisfy `Default` but `Shared<T>` does not, so we can avoid all current pointer types if we used `impl Clearable T where T: Copy+Default` instead.  

I added this in ccb563e but reverted it in 88b4c4f because `Shared<T>` does not seem so dangerous right now.  I'd hope Rust gets type-level numerics before any new dangerous `Shared<T>` abstractions and any such abstractions are likely to satisfy `Default` anyways. 

We do drop a zeroed object as a result of reverting the `Default` bounds, but afaik the worst case would be dropping a zeroed `Shared<T>`, whish does nothing itself.  If anything worse happens, then you can revert the revert 88b4c4f of course.  :) 