### PR TITLE
Make hide_mem support unsized and export it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 mod clear_on_drop;
 mod clear_stack_on_return;
 mod fnoption;
-mod hide;
+pub mod hide;
 
 pub use clear_on_drop::*;
 pub use clear_stack_on_return::*;


### PR DESCRIPTION
I'm not sure, but `hide_mem` might be worth exporting for other crates to use.  

I went ahead and made `hide_mem` support for unsized like in https://github.com/cesarb/clear_on_drop/pull/5 but slightly cleaner.  I'm not exactly sure if anything should be done with `hide_ptr` there.