### PR TITLE
Add delegation impls for AsRef, AsMut, Hash, and comparison traits

### DIFF
--- a/src/clear_on_drop.rs
+++ b/src/clear_on_drop.rs
@@ -1,3 +1,4 @@
+use std::borrow::{Borrow, BorrowMut};
 use std::cmp::Ordering;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -140,6 +141,32 @@ impl<P, T: ?Sized> AsMut<T> for ClearOnDrop<P>
     #[inline]
     fn as_mut(&mut self) -> &mut T {
         AsMut::as_mut(&mut self._place)
+    }
+}
+
+// std::borrow traits
+
+// The `T: Clear` bound avoids a conflict with the blanket impls
+// `impl<T> Borrow<T> for T` and `impl<T> BorrowMut<T> for T`, since
+// `ClearOnDrop<_>` is not `Clear`.
+
+impl<P, T: ?Sized> Borrow<T> for ClearOnDrop<P>
+    where P: DerefMut + Borrow<T>,
+          P::Target: Clear,
+          T: Clear
+{
+    fn borrow(&self) -> &T {
+        Borrow::borrow(&self._place)
+    }
+}
+
+impl<P, T: ?Sized> BorrowMut<T> for ClearOnDrop<P>
+    where P: DerefMut + BorrowMut<T>,
+          P::Target: Clear,
+          T: Clear
+{
+    fn borrow_mut(&mut self) -> &mut T {
+        BorrowMut::borrow_mut(&mut self._place)
     }
 }
 

--- a/src/clear_on_drop.rs
+++ b/src/clear_on_drop.rs
@@ -155,6 +155,7 @@ impl<P, T: ?Sized> Borrow<T> for ClearOnDrop<P>
           P::Target: Clear,
           T: Clear
 {
+    #[inline]
     fn borrow(&self) -> &T {
         Borrow::borrow(&self._place)
     }
@@ -165,6 +166,7 @@ impl<P, T: ?Sized> BorrowMut<T> for ClearOnDrop<P>
           P::Target: Clear,
           T: Clear
 {
+    #[inline]
     fn borrow_mut(&mut self) -> &mut T {
         BorrowMut::borrow_mut(&mut self._place)
     }

--- a/src/clear_on_drop.rs
+++ b/src/clear_on_drop.rs
@@ -148,6 +148,58 @@ impl<P> Hash for ClearOnDrop<P>
     fn hash<H: Hasher>(&self, state: &mut H) {  self._place.hash(state);  }
 }
 
+impl<P,Q> PartialEq<ClearOnDrop<Q>> for ClearOnDrop<P>
+    where P: DerefMut + PartialEq<Q>,
+          P::Target: Clear,
+          Q: DerefMut,
+          Q::Target: Clear,
+{
+    fn eq(&self, other: &ClearOnDrop<Q>) -> bool {
+        self._place.eq(&other._place)
+    }
+    fn ne(&self, other: &ClearOnDrop<Q>) -> bool {
+        self._place.ne(&other._place)
+    }
+}
+
+impl<P> Eq for ClearOnDrop<P>
+    where P: DerefMut + Eq,
+          P::Target: Clear
+{ }
+
+impl<P,Q> PartialOrd<ClearOnDrop<Q>> for ClearOnDrop<P>
+    where P: DerefMut + PartialOrd<Q>,
+          P::Target: Clear,
+          Q: DerefMut,
+          Q::Target: Clear,
+{
+    fn partial_cmp(&self, other: &ClearOnDrop<Q>) -> Option<::std::cmp::Ordering> {
+        self._place.partial_cmp(&other._place)
+    }
+
+    fn lt(&self, other: &ClearOnDrop<Q>) -> bool {
+        self._place.lt(&other._place)
+    }
+    fn le(&self, other: &ClearOnDrop<Q>) -> bool {
+        self._place.le(&other._place)
+    }
+    fn gt(&self, other: &ClearOnDrop<Q>) -> bool {
+        self._place.gt(&other._place)
+    }
+    fn ge(&self, other: &ClearOnDrop<Q>) -> bool {
+        self._place.ge(&other._place)
+    }
+}
+
+impl<P> Ord for ClearOnDrop<P>
+    where P: DerefMut + Ord,
+          P::Target: Clear
+{
+    fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
+        self._place.cmp(&other._place)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::ClearOnDrop;

--- a/src/clear_on_drop.rs
+++ b/src/clear_on_drop.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::ops::{Deref, DerefMut};
+use std::hash::{Hash,Hasher};
 
 use clear::Clear;
 
@@ -138,6 +139,13 @@ impl<T, P> AsMut<T> for ClearOnDrop<P>
     fn as_mut(&mut self) -> &mut T {
         AsMut::as_mut(&mut self._place)
     }
+}
+
+impl<P> Hash for ClearOnDrop<P>
+    where P: DerefMut + Hash,
+          P::Target: Clear
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {  self._place.hash(state);  }
 }
 
 #[cfg(test)]

--- a/src/clear_on_drop.rs
+++ b/src/clear_on_drop.rs
@@ -120,6 +120,26 @@ impl<P> Drop for ClearOnDrop<P>
     }
 }
 
+impl<T, P> AsRef<T> for ClearOnDrop<P>
+    where P: DerefMut + AsRef<T>,
+          P::Target: Clear
+{
+    #[inline]
+    fn as_ref(&self) -> &T {
+        AsRef::as_ref(&self._place)
+    }
+}
+
+impl<T, P> AsMut<T> for ClearOnDrop<P>
+    where P: DerefMut + AsMut<T>,
+          P::Target: Clear
+{
+    #[inline]
+    fn as_mut(&mut self) -> &mut T {
+        AsMut::as_mut(&mut self._place)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::ClearOnDrop;


### PR DESCRIPTION
These are delegations to the reference/container P, not the underlying type T, as that gives the user the most flexibility, including maybe using constant time comparisons. 

There is no obvious way to delegate `Borrow` and `BorrowMut` now that `T` is no longer a type parameter of `ClearOnDrop` itself.  I doubt that's a problem since I never got those games like `HashSet<ClearOnDrop<Owned<T>>>` to work anyways.  See https://github.com/burdges/clear_on_drop/blob/owned_fail/src/owned.rs#L52 