### PR TITLE
Is a drop_in_place needed?

### DIFF
--- a/src/clear.rs
+++ b/src/clear.rs
@@ -61,6 +61,7 @@ impl<T: ?Sized> Clear for T
     fn clear(&mut self) {
         let size = mem::size_of_val(self);
         unsafe {
+            ptr::drop_in_place(self);
             let ptr = self as *mut Self;
             ptr::write_bytes(ptr as *mut u8, 0, size);
             hide_mem_impl::<Self>(ptr);

--- a/src/clear.rs
+++ b/src/clear.rs
@@ -61,8 +61,8 @@ impl<T: ?Sized> Clear for T
     fn clear(&mut self) {
         let size = mem::size_of_val(self);
         unsafe {
-            ptr::drop_in_place(self);
             let ptr = self as *mut Self;
+            ptr::drop_in_place(ptr);
             ptr::write_bytes(ptr as *mut u8, 0, size);
             hide_mem_impl::<Self>(ptr);
             Self::initialize(ptr);


### PR DESCRIPTION
There is nothing wrong with types that contain dynamic allocations being `InitializableFromZeroed`, right?  If I understand, there is nothing in `Clear::clear` https://github.com/cesarb/clear_on_drop/blob/master/src/clear.rs#L61 that calls `<Self as Drop>::drop(self)` currently, right? 

Is the issue that dropping does not propagate `clear` quite right?  If say, I wanted to clear a type containing allocations then I should do something like :
```
struct MyType {
    foo: usize,
    xs: Vec<X>,
    ys: Box<[Y]>
}

impl Clear for MyType {
    clear(&mut mt) {
        self.foo = 0;
        self.xs.clear();
        self.ys.clear();
    }
}
```
If `MyType` were an `enum` then they'd need to call ` ptr::write_bytes(mt as *mut u8, 0, size_of(MyType));` themselves even.