### PR TITLE
no_std support (closes #11)

### DIFF
--- a/src/clear.rs
+++ b/src/clear.rs
@@ -39,8 +39,8 @@
 //! assert!(!as_bytes(&place).contains(&0x41));
 //! ```
 
-use std::mem;
-use std::ptr;
+use core::mem;
+use core::ptr;
 
 use hide::hide_mem_impl;
 

--- a/src/clear_on_drop.rs
+++ b/src/clear_on_drop.rs
@@ -1,10 +1,10 @@
-use std::borrow::{Borrow, BorrowMut};
-use std::cmp::Ordering;
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::mem;
-use std::ops::{Deref, DerefMut};
-use std::ptr;
+use core::borrow::{Borrow, BorrowMut};
+use core::cmp::Ordering;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::mem;
+use core::ops::{Deref, DerefMut};
+use core::ptr;
 
 use clear::Clear;
 
@@ -138,7 +138,7 @@ impl<P> Drop for ClearOnDrop<P>
     }
 }
 
-// std::convert traits
+// core::convert traits
 
 impl<P, T: ?Sized> AsRef<T> for ClearOnDrop<P>
     where P: DerefMut + AsRef<T>,
@@ -160,7 +160,7 @@ impl<P, T: ?Sized> AsMut<T> for ClearOnDrop<P>
     }
 }
 
-// std::borrow traits
+// core::borrow traits
 
 // The `T: Clear` bound avoids a conflict with the blanket impls
 // `impl<T> Borrow<T> for T` and `impl<T> BorrowMut<T> for T`, since
@@ -188,7 +188,7 @@ impl<P, T: ?Sized> BorrowMut<T> for ClearOnDrop<P>
     }
 }
 
-// std::hash traits
+// core::hash traits
 
 impl<P> Hash for ClearOnDrop<P>
     where P: DerefMut + Hash,
@@ -200,7 +200,7 @@ impl<P> Hash for ClearOnDrop<P>
     }
 }
 
-// std::cmp traits
+// core::cmp traits
 
 impl<P, Q> PartialEq<ClearOnDrop<Q>> for ClearOnDrop<P>
     where P: DerefMut + PartialEq<Q>,

--- a/src/hide.c
+++ b/src/hide.c
@@ -3,7 +3,7 @@
 __attribute__ ((visibility ("hidden")))
 #endif
 #endif
-void *clear_on_drop_hide(void *ptr) {
+unsigned char *clear_on_drop_hide(unsigned char *ptr) {
     #if defined(__GNUC__)
     /* Not needed with MSVC, since Rust uses LLVM and LTO can't inline this. */
     __asm__ volatile ("" : "=r" (ptr) : "0" (ptr) : "memory");

--- a/src/hide.rs
+++ b/src/hide.rs
@@ -65,16 +65,14 @@ mod nightly {
 // When a C compiler is available, a dummy C function can be used.
 #[cfg(not(feature = "no_cc"))]
 mod cc {
-    use std::os::raw::c_void;
-
     extern "C" {
-        fn clear_on_drop_hide(ptr: *mut c_void) -> *mut c_void;
+        fn clear_on_drop_hide(ptr: *mut u8) -> *mut u8;
     }
 
     #[inline]
     pub fn hide_mem_impl<T: ?Sized>(ptr: *mut T) {
         unsafe {
-            clear_on_drop_hide(ptr as *mut c_void);
+            clear_on_drop_hide(ptr as *mut u8);
         }
     }
 }
@@ -83,7 +81,7 @@ mod cc {
 // and hope this is enough to confuse the optimizer.
 #[cfg(all(feature = "no_cc", not(feature = "nightly")))]
 mod fallback {
-    use std::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
+    use core::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
 
     #[inline]
     pub fn hide_mem_impl<T: ?Sized>(ptr: *mut T) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "nightly", feature(asm))]
 #![cfg_attr(feature = "nightly", feature(i128_type))]
 #![cfg_attr(feature = "nightly", feature(specialization))]
@@ -54,6 +55,9 @@
 //! used unless necessary, since it's less reliable. It is enabled by
 //! the `no_cc` feature, works on stable Rust, and does not need a C
 //! compiler.
+
+#[cfg(test)]
+extern crate core;
 
 pub mod clear;
 mod clear_on_drop;


### PR DESCRIPTION
Changes references from std:: to core:: where applicable, ensuring the crate builds in no_std environments.