### PR TITLE
Implement ZeroSafe for fixed-size arrays [ZeroSafe; N]

### DIFF
--- a/src/clear.rs
+++ b/src/clear.rs
@@ -125,3 +125,20 @@ unsafe impl ZeroSafe for u64 {}
 unsafe impl ZeroSafe for i128 {}
 #[cfg(feature = "nightly")]
 unsafe impl ZeroSafe for u128 {}
+
+macro_rules! array_impl_zerosafe {
+    ($($N:expr)+) => {
+        $(
+            unsafe impl<T: ZeroSafe> ZeroSafe for [T; $N] {}
+        )+
+    }
+}
+
+// Implement for fixed-size arrays of ZeroSafe up to 64
+array_impl_zerosafe!{
+     0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
+    16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
+    32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47
+    48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63
+    64
+}

--- a/src/clear_on_drop.rs
+++ b/src/clear_on_drop.rs
@@ -343,6 +343,17 @@ mod tests {
     }
 
     #[test]
+    fn on_fixed_size_array() {
+        let mut place: [u32; 4] = Default::default();
+        {
+            let mut clear = ClearOnDrop::new(&mut place);
+            clear.copy_from_slice(&DATA);
+            assert_eq!(&clear[..], DATA);
+        }
+        assert_eq!(place, [0; 4]);
+    }
+
+    #[test]
     fn on_slice() {
         let mut place: [u32; 4] = Default::default();
         {


### PR DESCRIPTION
Like the array impls in the standardlib, this uses a macro to generate
an impl for each length. Unlike those impls, they run up to length 64
instead of 32 to cover more arrays.