### PR TITLE
Update hide.rs from asm! to llvm_asm!

### DIFF
--- a/src/hide.rs
+++ b/src/hide.rs
@@ -35,7 +35,7 @@ mod impls {
         #[inline]
         default fn hide_mem_impl(ptr: *mut Self) {
             unsafe {
-                asm!("" : : "r" (ptr as *mut u8) : "memory");
+                llvm_asm!("" : : "r" (ptr as *mut u8) : "memory");
             }
         }
     }
@@ -44,7 +44,7 @@ mod impls {
         #[inline]
         fn hide_mem_impl(ptr: *mut Self) {
             unsafe {
-                asm!("" : "=*m" (ptr) : "*0" (ptr));
+                llvm_asm!("" : "=*m" (ptr) : "*0" (ptr));
             }
         }
     }


### PR DESCRIPTION
`asm!` is now deprecated in nightly rust and will pass errors when compiling.

I have changed two lines to the newer version, `llvm_asm!` so it can compile.

As soon as possible, can you release the next version (0.2.4) so this can be fixed with the changes mentioned.