### PR TITLE
Exclude nightly features on stable rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(feature = "nightly", feature(llvm_asm, i128_type, specialization))]
+#![cfg_attr(all(nightly, feature = "nightly"), feature(llvm_asm, i128_type, specialization))]
 #![deny(missing_docs)]
 
 //! Helpers for clearing sensitive data on the stack and heap.


### PR DESCRIPTION
Using clear_on_drop on stable rust results in the following error:

```
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> src/lib.rs:2:34
  |
2 | #![cfg_attr(feature = "nightly", feature(llvm_asm, i128_type, specialization))]
  |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: the feature `i128_type` has been stable since 1.26.0 and no longer requires an attribute to enable
```

This PR uses an additional `nightly` predicate to prevent this error on
stable rust