### PR TITLE
llvm_asm macros was changed to an asm

### DIFF
--- a/src/clear_stack_on_return.rs
+++ b/src/clear_stack_on_return.rs
@@ -25,9 +25,9 @@ pub fn clear_stack_on_return<F, R>(pages: usize, mut f: F) -> R
 where
     F: FnMut() -> R,
 {
-    let _clear = ClearStackOnDrop { pages: pages };
+    let _clear = ClearStackOnDrop { pages };
     // Do not inline f to make sure clear_stack uses the same stack space.
-    hide_ptr::<&mut FnMut() -> R>(&mut f)()
+    hide_ptr::<&mut dyn FnMut() -> R>(&mut f)()
 }
 
 /// Calls a closure and overwrites its stack on return.

--- a/src/hide.rs
+++ b/src/hide.rs
@@ -27,6 +27,8 @@ pub use self::impls::hide_mem_impl;
 // On nightly, inline assembly can be used.
 #[cfg(feature = "nightly")]
 mod impls {
+    use core::arch::asm;
+
     trait HideMemImpl {
         fn hide_mem_impl(ptr: *mut Self);
     }
@@ -35,8 +37,8 @@ mod impls {
         #[inline]
         default fn hide_mem_impl(ptr: *mut Self) {
             unsafe {
-                llvm_asm!("" : : "r" (ptr as *mut u8) : "memory");
-                // asm!("", in(reg) (ptr as *mut u8), options(nostack));
+                //llvm_asm!("" : : "r" (ptr as *mut u8) : "memory");
+                asm!("/* {0} */", in(reg) (ptr as *mut u8), options(nostack));
             }
         }
     }
@@ -45,8 +47,8 @@ mod impls {
         #[inline]
         fn hide_mem_impl(ptr: *mut Self) {
             unsafe {
-                llvm_asm!("" : "=*m" (ptr) : "*0" (ptr));
-                // asm!("", in(reg) ptr, options(nostack));
+                //llvm_asm!("" : "=*m" (ptr) : "*0" (ptr));
+                asm!("/* {0} */", in(reg) ptr, options(nostack));
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(feature = "nightly", feature(llvm_asm, i128_type, specialization))]
+#![cfg_attr(feature = "nightly", feature(min_specialization))]
 #![deny(missing_docs)]
 
 //! Helpers for clearing sensitive data on the stack and heap.


### PR DESCRIPTION
New versions of Rust nightly fail to build old code:
```
/clear_on_drop-0.2.4/src/hide.rs:38:17
   |
38 |                 llvm_asm!("" : : "r" (ptr as *mut u8) : "memory");
   |                 ^^^^^^^^

error: cannot find macro `llvm_asm` in this scope
```

And https://github.com/rust-lang/rust/issues/72965 which prevents fix of #23 was also resolved.
So I changed code back to `asm` usage with additional tweak - putting unused argument in comments.