### PR TITLE
Request to change `ClearOnDrop` to hold `ManuallyDrop<P>` rather than `P`.

### DIFF
--- a/src/clear.rs
+++ b/src/clear.rs
@@ -65,7 +65,11 @@ where
             let ptr = self as *mut Self;
             ptr::drop_in_place(ptr);
             ptr::write_bytes(ptr as *mut u8, 0, size);
-            hide_mem_impl::<Self>(ptr);
+
+            if !cfg!(miri) {
+                hide_mem_impl::<Self>(ptr);
+            }
+
             Self::initialize(ptr);
         }
     }
@@ -135,7 +139,7 @@ macro_rules! array_impl_zerosafe {
 }
 
 // Implement for fixed-size arrays of ZeroSafe up to 64
-array_impl_zerosafe!{
+array_impl_zerosafe! {
      0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15
     16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
     32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47

--- a/src/clear_on_drop.rs
+++ b/src/clear_on_drop.rs
@@ -161,6 +161,7 @@ where
                 != 0
             {
                 self.clear();
+                ManuallyDrop::drop(&mut self._place);
             }
         }
     }

--- a/src/hide.rs
+++ b/src/hide.rs
@@ -88,6 +88,7 @@ mod impls {
 }
 
 #[cfg(test)]
+#[cfg(not(miri))]
 mod tests {
     struct Place {
         data: [u32; 4],


### PR DESCRIPTION
While I do not necessarily expect this to be merged, as this is maybe not the most urgent change, it does reduce the potential for UB in a couple of places.

The main reason for this change is the following original implementation:
```rust
pub fn into_uncleared_place(c: Self) -> P {
    unsafe {
        let place = ptr::read(&c._place);
        mem::forget(c);
        place
    }
}
````
When place is read into through a `*const P` it creates a `Unique` retag of the underlying value, which gets invalidated by the consuming call of `mem::forget(c)` as this causes a new `Unique` retag. While this is not inherently UB there it does violate some safety invariants that make unsafe code more predictable.

By changing `ClearOnDrop` to hold `ManuallyDrop<P>` rather than just `P`, we avoid having to forget `c` and thus need not invalided our borrow tag.

There since now we do not forget our `ClearOnDrop`, if we do not want our value to be cleared we zero out the `ManuallyDrop<P>` as follows:
```rust
pub fn into_uncleared_place(mut c: Self) -> P {
    unsafe {
        let place = ptr::read(&c._place);
        ptr::write_bytes(
            &mut c._place as *mut _ as *mut u8,
            0,
            mem::size_of::<ManuallyDrop<P>>(),
        );
        ManuallyDrop::into_inner(place)
    }
}
```
This case is then checked for in the drop implementation as such:
```rust
fn drop(&mut self) {
    let ptr = &mut self._place as *mut _ as *mut u8;
    unsafe {
        if (0..mem::size_of::<ManuallyDrop<P>>() as isize)
            .fold(0, |acc, i| acc + *ptr.offset(i) as i32)
            != 0
        {
            self.clear();
            ManuallyDrop::drop(&mut self._place);
        }
    }
}
```

These are the results of running `cargo bench` on the `ub-drop-clear` branch:
```
clear_on_drop_small     time:   [1.0799 ns 1.0837 ns 1.0877 ns]
                        change: [+0.6411% +0.9332% +1.2594%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

clear_on_drop_medium    time:   [7.2033 ns 7.2378 ns 7.2762 ns]
                        change: [+1.2775% +1.7232% +2.2066%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

clear_on_drop_large     time:   [196.54 ns 197.07 ns 197.66 ns]
                        change: [+0.6144% +1.0976% +1.5578%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
```

I totally understand if you do not see this as a necessary addition, I had fun working on it anyways! :D
